### PR TITLE
Fixed Windows filename error

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function templateCompiler() {
       var fileName = n === 0 ? file.relative : file.relative.slice(0, -n);
       var compilerOutput = compiler.precompile(file.contents.toString(), false);
 
-      file.contents = new Buffer("Ember.TEMPLATES['" + fileName +"'] = Ember.Handlebars.template(" + compilerOutput + ");");
+      file.contents = new Buffer("Ember.TEMPLATES['" + fileName.replace(path.sep, '/') +"'] = Ember.Handlebars.template(" + compilerOutput + ");");
     }
 
     this.push(file);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-ember-template-compiler",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A gulp plugin that precompiles Handlebars templates for Ember.js.",
   "author": "DaoJing Gao <me@gaodaojing.com>",
   "homepage": "https://github.com/gaodaojing/gulp-ember-template-compiler",


### PR DESCRIPTION
Windows filenames were not loading correctly because of the backslash that windows uses instead of the forward slash.

I fixed that error by having the filename variable replace the system path separator variable with a forward slash. It has been tested in Windows and it works.